### PR TITLE
Add simple_bot skeleton with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Simple Bot
+
+CLI trading bot for Bybit futures (Testnet by default).
+
+## Installation
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+1. Copy `config.yaml` and edit API keys and parameters.
+2. Create `.env` if needed for additional secrets.
+
+## Running in Testnet
+
+```bash
+python -m simple_bot.main --config config.yaml
+```
+
+## Switching to Mainnet
+
+Edit `config.yaml`:
+```yaml
+exchange:
+  testnet: false
+```
+
+Then run the bot again.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,23 @@
+exchange:
+  id: bybit
+  api_key: "YOUR_API_KEY"
+  secret: "YOUR_SECRET"
+  testnet: true
+  testnet_url: "https://api-testnet.bybit.com"
+  mainnet_url: "https://api.bybit.com"
+
+symbol: "BTC/USDT"
+timeframe: "1h"
+limit: 200
+leverage: 1
+indicators:
+  ema_fast: 50
+  ema_slow: 200
+  macd_fast: 12
+  macd_slow: 26
+  macd_signal: 9
+  atr_period: 14
+risk:
+  sl_atr: 1.5
+  tp_atr: 3.0
+poll_seconds: 60

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+ccxt
+pandas
+numpy<2.0
+pandas-ta
+pyyaml
+python-dotenv
+pytest

--- a/simple_bot/exchange.py
+++ b/simple_bot/exchange.py
@@ -1,0 +1,90 @@
+"""Exchange interaction logic using ccxt."""
+
+from __future__ import annotations
+
+import ccxt
+import pandas as pd
+
+from typing import Any, Dict, List
+
+
+class Exchange:
+    """Wrapper around ccxt exchange for Bybit futures."""
+
+    def __init__(self, cfg: Dict[str, Any]):
+        self.cfg = cfg
+        self.symbol = cfg["symbol"]
+        exchange_cfg = cfg["exchange"]
+        id_ = exchange_cfg["id"]
+        params: Dict[str, Any] = {
+            "apiKey": exchange_cfg.get("api_key"),
+            "secret": exchange_cfg.get("secret"),
+            "enableRateLimit": True,
+        }
+        if exchange_cfg.get("testnet"):
+            params["urls"] = {"api": exchange_cfg["testnet_url"]}
+        else:
+            params["urls"] = {"api": exchange_cfg.get("mainnet_url", "")}
+        self.client = getattr(ccxt, id_)(params)
+        if exchange_cfg.get("testnet"):
+            self.client.set_sandbox_mode(True)
+        self.client.options["defaultType"] = "future"
+        leverage = cfg.get("leverage", 1)
+        try:
+            self.client.private_linear_post_position_leverage_save({
+                "symbol": self.symbol.replace("/", ""),
+                "buy_leverage": leverage,
+                "sell_leverage": leverage,
+            })
+        except Exception:
+            pass
+
+    def fetch_ohlcv(self, limit: int, timeframe: str) -> pd.DataFrame:
+        """Fetch OHLCV data and return DataFrame."""
+        data = self.client.fetch_ohlcv(self.symbol, timeframe=timeframe, limit=limit)
+        df = pd.DataFrame(data, columns=["timestamp", "open", "high", "low", "close", "volume"])
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+        return df
+
+    def open_position(self, side: str, size: float, sl: float, tp: float) -> None:
+        """Place market order with SL/TP."""
+        params = {
+            "time_in_force": "GoodTillCancel",
+            "reduce_only": False,
+            "close_on_trigger": False,
+        }
+        self.client.create_market_order(self.symbol, side, size, params=params)
+        if sl:
+            self.client.create_order(
+                self.symbol,
+                "STOP",
+                side="sell" if side == "buy" else "buy",
+                amount=size,
+                params={"stop_price": sl},
+            )
+        if tp:
+            self.client.create_order(
+                self.symbol,
+                "TAKE_PROFIT",
+                side="sell" if side == "buy" else "buy",
+                amount=size,
+                params={"stop_price": tp},
+            )
+
+    def position_open(self) -> bool:
+        """Check if there is an open position."""
+        positions = self.client.fetch_positions([self.symbol])
+        for pos in positions:
+            if float(pos.get("contracts", 0)) > 0:
+                return True
+        return False
+
+    def check_positions(self) -> List[Dict[str, Any]]:
+        """Return current positions."""
+        return self.client.fetch_positions([self.symbol])
+
+    def balance(self) -> float:
+        """Return account balance in USDT."""
+        balance = self.client.fetch_balance()
+        usdt = balance.get("USDT", {})
+        return float(usdt.get("free", 0))

--- a/simple_bot/indicators.py
+++ b/simple_bot/indicators.py
@@ -1,0 +1,26 @@
+"""Indicator helper functions."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pandas_ta as ta
+
+
+def add_macd(df: pd.DataFrame, fast: int, slow: int, signal: int) -> pd.DataFrame:
+    """Add MACD indicators to DataFrame."""
+    macd = ta.macd(df['close'], fast=fast, slow=slow, signal=signal)
+    return pd.concat([df, macd], axis=1)
+
+
+def add_ema(df: pd.DataFrame, length: int, column: str = 'close') -> pd.DataFrame:
+    """Add EMA column."""
+    ema = ta.ema(df[column], length=length)
+    df[f'ema_{length}'] = ema
+    return df
+
+
+def add_atr(df: pd.DataFrame, length: int) -> pd.DataFrame:
+    """Add ATR column."""
+    atr = ta.atr(df['high'], df['low'], df['close'], length=length)
+    df[f'atr_{length}'] = atr
+    return df

--- a/simple_bot/main.py
+++ b/simple_bot/main.py
@@ -1,0 +1,50 @@
+"""Entry point for the trading bot."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import pandas as pd
+
+from .exchange import Exchange
+from .indicators import add_macd, add_ema, add_atr
+from .strategy import generate_signal
+from .risk import position_size_usd, calc_sl_tp
+from .utils import load_cfg, log
+
+
+def run(cfg_path: str) -> None:
+    cfg = load_cfg(cfg_path)
+    exchange = Exchange(cfg)
+    poll = cfg.get("poll_seconds", 60)
+    while True:
+        try:
+            df = exchange.fetch_ohlcv(limit=cfg["limit"], timeframe=cfg["timeframe"])
+            df = add_macd(df, cfg["indicators"]["macd_fast"], cfg["indicators"]["macd_slow"], cfg["indicators"]["macd_signal"])
+            df = add_ema(df, cfg["indicators"]["ema_fast"])
+            df = add_ema(df, cfg["indicators"]["ema_slow"])
+            df = add_atr(df, cfg["indicators"]["atr_period"])
+            signal = generate_signal(df, {**cfg["indicators"], **cfg["risk"]})
+            log("INFO", f"Signal: {signal.side}")
+            if signal.side != "NONE" and not exchange.position_open():
+                price = df["close"].iloc[-1]
+                balance = exchange.balance()
+                size = position_size_usd(balance, price, cfg.get("risk", {}))
+                sl, tp = calc_sl_tp(price, signal.side, df, {**cfg["indicators"], **cfg["risk"]})
+                log("INFO", f"Open {signal.side} size {size:.4f} SL {sl:.2f} TP {tp:.2f}")
+                exchange.open_position("buy" if signal.side == "LONG" else "sell", size, sl, tp)
+        except Exception as err:
+            log("ERROR", str(err))
+        time.sleep(poll)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple trading bot")
+    parser.add_argument("--config", default="config.yaml", help="Path to config file")
+    args = parser.parse_args()
+    run(args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/simple_bot/risk.py
+++ b/simple_bot/risk.py
@@ -1,0 +1,27 @@
+"""Risk management helpers."""
+
+from __future__ import annotations
+
+from typing import Dict
+import pandas as pd
+
+
+def position_size_usd(balance: float, price: float, cfg: Dict[str, float]) -> float:
+    """Calculate position size in contracts."""
+    risk_pct = cfg.get('risk_pct', 1) / 100
+    size = (balance * risk_pct) / price
+    return size
+
+
+def calc_sl_tp(price: float, side: str, df: pd.DataFrame, cfg: Dict[str, float]) -> tuple[float, float]:
+    """Calculate stop-loss and take-profit based on ATR."""
+    atr = df[f"atr_{cfg['atr_period']}"].iloc[-1]
+    sl_atr = cfg['sl_atr'] * atr
+    tp_atr = cfg['tp_atr'] * atr
+    if side == 'LONG':
+        sl = price - sl_atr
+        tp = price + tp_atr
+    else:
+        sl = price + sl_atr
+        tp = price - tp_atr
+    return sl, tp

--- a/simple_bot/strategy.py
+++ b/simple_bot/strategy.py
@@ -1,0 +1,30 @@
+"""Trading strategy logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd
+
+
+@dataclass
+class Signal:
+    """Trading signal dataclass."""
+
+    side: str
+    sl_atr: float
+    tp_atr: float
+
+
+def generate_signal(df: pd.DataFrame, cfg: Dict[str, float]) -> Signal:
+    """Generate trading signal based on MACD and EMA crossover."""
+    ema_fast = df[f"ema_{cfg['ema_fast']}"]
+    ema_slow = df[f"ema_{cfg['ema_slow']}"]
+    hist = df['MACDh_12_26_9'] if 'MACDh_12_26_9' in df.columns else df['MACDh']
+    side = 'NONE'
+    if hist.iloc[-1] > 0 and ema_fast.iloc[-1] > ema_slow.iloc[-1]:
+        side = 'LONG'
+    elif hist.iloc[-1] < 0 and ema_fast.iloc[-1] < ema_slow.iloc[-1]:
+        side = 'SHORT'
+    return Signal(side=side, sl_atr=cfg['sl_atr'], tp_atr=cfg['tp_atr'])

--- a/simple_bot/utils.py
+++ b/simple_bot/utils.py
@@ -1,0 +1,45 @@
+"""Utility functions for simple_bot."""
+
+from __future__ import annotations
+
+import datetime
+import yaml
+from pathlib import Path
+from typing import Any, Dict
+
+from dotenv import load_dotenv
+
+
+COLORS = {
+    "INFO": "\033[94m",
+    "ERROR": "\033[91m",
+    "ENDC": "\033[0m",
+}
+
+
+def log(level: str, message: str) -> None:
+    """Print colored log message with timestamp.
+
+    Args:
+        level: Log level string.
+        message: Message to print.
+    """
+    color = COLORS.get(level, "")
+    endc = COLORS["ENDC"] if color else ""
+    timestamp = datetime.datetime.utcnow().isoformat()
+    print(f"{color}[{timestamp}] {level}: {message}{endc}")
+
+
+def load_cfg(path: str | Path) -> Dict[str, Any]:
+    """Load YAML configuration and environment variables.
+
+    Args:
+        path: Path to YAML config.
+
+    Returns:
+        Parsed configuration as dictionary.
+    """
+    load_dotenv()
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    return cfg

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,34 @@
+"""Tests for strategy module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from simple_bot.strategy import generate_signal, Signal
+from simple_bot.indicators import add_macd, add_ema, add_atr
+
+
+def test_generate_signal() -> None:
+    np.random.seed(0)
+    data = np.random.rand(300, 5) * 100
+    df = pd.DataFrame(data, columns=["open", "high", "low", "close", "volume"])
+    df = add_macd(df, 12, 26, 9)
+    df = add_ema(df, 50)
+    df = add_ema(df, 200)
+    df = add_atr(df, 14)
+    cfg = {
+        "ema_fast": 50,
+        "ema_slow": 200,
+        "sl_atr": 1.5,
+        "tp_atr": 3.0,
+        "atr_period": 14,
+    }
+    signal = generate_signal(df, cfg)
+    assert isinstance(signal, Signal)
+    assert signal.side in {"LONG", "SHORT", "NONE"}


### PR DESCRIPTION
## Summary
- implement a CLI trading bot skeleton under `simple_bot` package
- include helper modules for exchange, indicators, risk, and strategy
- provide config and utility functions
- add example configuration and README usage instructions
- include unit test for strategy

## Testing
- `python -m venv venv`
- `source venv/bin/activate`
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bc9cd352c8333ae8cc31ddf3ba6c9