### PR TITLE
Improve risk handling for small positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ pip install -r requirements.txt
 
 1. Copy `config.yaml` and edit API keys and parameters.
 2. Create `.env` if needed for additional secrets.
+3. Adjust the risk settings if desired. `risk_pct` controls the percentage of the
+   balance used per trade and `min_size` sets the minimum contract size allowed.
 
 ## Running in Testnet
 

--- a/config.yaml
+++ b/config.yaml
@@ -20,4 +20,6 @@ indicators:
 risk:
   sl_atr: 1.5
   tp_atr: 3.0
+  risk_pct: 1
+  min_size: 0.001
 poll_seconds: 60

--- a/simple_bot/main.py
+++ b/simple_bot/main.py
@@ -31,9 +31,22 @@ def run(cfg_path: str) -> None:
                 price = df["close"].iloc[-1]
                 balance = exchange.balance()
                 size = position_size_usd(balance, price, cfg.get("risk", {}))
-                sl, tp = calc_sl_tp(price, signal.side, df, {**cfg["indicators"], **cfg["risk"]})
-                log("INFO", f"Open {signal.side} size {size:.4f} SL {sl:.2f} TP {tp:.2f}")
-                exchange.open_position("buy" if signal.side == "LONG" else "sell", size, sl, tp)
+                if size <= 0:
+                    log("ERROR", "Position size below exchange minimum; trade skipped")
+                    continue
+                sl, tp = calc_sl_tp(
+                    price,
+                    signal.side,
+                    df,
+                    {**cfg["indicators"], **cfg["risk"]},
+                )
+                log(
+                    "INFO",
+                    f"Open {signal.side} size {size:.4f} SL {sl:.2f} TP {tp:.2f}",
+                )
+                exchange.open_position(
+                    "buy" if signal.side == "LONG" else "sell", size, sl, tp
+                )
         except Exception as err:
             log("ERROR", str(err))
         time.sleep(poll)

--- a/simple_bot/risk.py
+++ b/simple_bot/risk.py
@@ -7,9 +7,17 @@ import pandas as pd
 
 
 def position_size_usd(balance: float, price: float, cfg: Dict[str, float]) -> float:
-    """Calculate position size in contracts."""
-    risk_pct = cfg.get('risk_pct', 1) / 100
+    """Calculate position size in contracts.
+
+    Ensures the returned size respects the configured minimum order size.
+    Returns ``0.0`` when the calculated size is below the minimum.
+    """
+
+    risk_pct = cfg.get("risk_pct", 1) / 100
     size = (balance * risk_pct) / price
+    min_size = cfg.get("min_size", 0.001)
+    if size < min_size:
+        return 0.0
     return size
 
 


### PR DESCRIPTION
## Summary
- document risk configuration in README
- allow configuring `risk_pct` and `min_size` in `config.yaml`
- enforce a minimum order size in `position_size_usd`
- skip trades when calculated size is below exchange minimum

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `python -m simple_bot.main --config config.yaml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c017c8c788333ab092b01f65f0dfd